### PR TITLE
small fixes and improvements with cookiecutter generation

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,8 +1,8 @@
 {
+  "package_name": "data_science_package",
+  "project_slug": "{{ cookiecutter.package_name }}",
   "project_name": "Data Science Project",
   "description": "A data science project template",
-  "project_slug": "data_science_project",
-  "package_name": "data_science_package",
   "author_name": "Author Name",
   "python_version": "3.11"
 }

--- a/{{cookiecutter.project_slug}}/config.yaml
+++ b/{{cookiecutter.project_slug}}/config.yaml
@@ -1,9 +1,12 @@
 metadata:
-  project_name: "{{ cookiecutter.project_slug }}"
+  project_name: "{{ cookiecutter.project_name }}"
   version: "v0.1.0"
   author: "{{ cookiecutter.author_name }}"
-  description: "Logistic regression example with synthetic data for reproducible research."
+  description: "{{ cookiecutter.description }}"
   tags: ["example", "logistic_regression", "synthetic_data"]
+  python_version: "{{ cookiecutter.python_version }}"
+  package_name: "{{ cookiecutter.package_name }}"
+  project_slug: "{{ cookiecutter.project_slug }}"
 
 random_seed: 42
 

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -1,30 +1,38 @@
 [project]
 name = "{{ cookiecutter.project_slug }}"
 version = "0.1.0"
-description = ""
+description = "{{ cookiecutter.description }}"
 authors = [{ name = "{{ cookiecutter.author_name }}" }]
 requires-python = ">=3.11"
 
 dependencies = [
-  "numpy",
-  "pandas",
-  "geopandas",
-  "matplotlib",
-  "pyyaml",
-  "ruff",
-  "pre-commit",
-  "typer",
-  "tqdm",
-  "scikit-learn",
-  "pymdown-extensions",
-  "mkdocstrings-python",
-  "mkdocs-material",
+    "numpy",
+    "pandas",
+    "geopandas",
+    "matplotlib",
+    "scikit-learn",
+    "typer",
+    "tqdm",
+    "pyyaml",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "ruff",
+    "pre-commit",
+]
+docs = [
+    "pymdown-extensions",
+    "mkdocstrings-python",
+    "mkdocs-material",
+]
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/{{ cookiecutter.package_name }}"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "FLY", "RUF", "B", "ICN"]
@@ -35,4 +43,4 @@ line-length = 140
 indent-width = 4
 
 [tool.ruff.isort]
-known-first-party = ["{{ cookiecutter.project_slug }}"]
+known-first-party = ["{{ cookiecutter.package_name }}"]

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/__init__.py
@@ -1,0 +1,6 @@
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    __version__ = "0.0.0"


### PR DESCRIPTION
fix: reorder params in cookiecutter.json so package_name and project_slug are set to same value by default

changed pyproject.toml so it can accept different package_name and project_slug

TODO: ensure that package_name is PEP compliant

Also, ensure that description reflects across files (config, pyproject.toml)